### PR TITLE
Add error handling to getting video resolution

### DIFF
--- a/mp4compose/src/main/java/com/daasuu/mp4compose/composer/Mp4Composer.java
+++ b/mp4compose/src/main/java/com/daasuu/mp4compose/composer/Mp4Composer.java
@@ -399,6 +399,15 @@ public class Mp4Composer {
             final int height = Integer.valueOf(rawHeight);
 
             return new Size(width, height);
+        } catch (IllegalArgumentException e) {
+            logger.error("MediaMetadataRetriever", "getVideoResolution IllegalArgumentException", e);
+            return null;
+        } catch (RuntimeException e) {
+            logger.error("MediaMetadataRetriever", "getVideoResolution RuntimeException", e);
+            return null;
+        } catch (Exception e) {
+            logger.error("MediaMetadataRetriever", "getVideoResolution Exception", e);
+            return null;
         } finally {
             try {
                 if (retriever != null) {


### PR DESCRIPTION
Added error handling to getVideoResolution method because it does not handle exceptions.
MediaMetadataRetriever.setDatasource may cause IllegalArgumentException or any other exceptions.