### PR TITLE
Add videoFormatMimeType parameter to select video format mime type.

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ dependencies {
 | trim | Trim both audio and video tracks to the provided start and end times, inclusive. Default does not trim anything from the start or end. |
 | flipVertical | Flip Vertical on exported video. Default `flipVertical = false`. |
 | flipHorizontal | Flip Horizontal on exported video. Default `flipHorizontal = false`. |
+| videoFormatMimeType | The mime type of the video format on exported video. Values can be MediaFormat.MIMETYPE_VIDEO_HEVC, MediaFormat.MIMETYPE_VIDEO_AVC, MediaFormat.MIMETYPE_VIDEO_MPEG4, MediaFormat.MIMETYPE_VIDEO_H263, etc. |
 
 
 

--- a/mp4compose/src/main/java/com/daasuu/mp4compose/composer/Mp4Composer.java
+++ b/mp4compose/src/main/java/com/daasuu/mp4compose/composer/Mp4Composer.java
@@ -50,6 +50,7 @@ public class Mp4Composer {
     private boolean flipHorizontal = false;
     private long trimStartMs = 0;
     private long trimEndMs = -1;
+    private String videoFormatMimeType;
     private EGLContext shareContext;
 
     private ExecutorService executorService;
@@ -152,6 +153,11 @@ public class Mp4Composer {
 
     public Mp4Composer timeScale(final int timeScale) {
         this.timeScale = timeScale;
+        return this;
+    }
+
+    public Mp4Composer videoFormatMimeType(String videoFormatMimeType) {
+        this.videoFormatMimeType = videoFormatMimeType;
         return this;
     }
 
@@ -282,6 +288,7 @@ public class Mp4Composer {
                             flipHorizontal,
                             trimStartMs,
                             trimEndMs,
+                            videoFormatMimeType,
                             shareContext
                     );
 

--- a/mp4compose/src/main/java/com/daasuu/mp4compose/composer/Mp4ComposerEngine.java
+++ b/mp4compose/src/main/java/com/daasuu/mp4compose/composer/Mp4ComposerEngine.java
@@ -3,6 +3,7 @@ package com.daasuu.mp4compose.composer;
 import android.media.*;
 import android.opengl.EGLContext;
 import android.os.Build;
+import android.text.TextUtils;
 import android.util.Size;
 import androidx.annotation.NonNull;
 import com.daasuu.mp4compose.FillMode;
@@ -62,6 +63,7 @@ class Mp4ComposerEngine {
             final boolean flipHorizontal,
             final long trimStartMs,
             final long trimEndMs,
+            final String videoFormatMimeType,
             final EGLContext shareContext
     ) throws IOException {
 
@@ -100,7 +102,7 @@ class Mp4ComposerEngine {
                 audioTrackIndex = 0;
             }
 
-            final MediaFormat actualVideoOutputFormat = createVideoOutputFormatWithAvailableEncoders(bitrate, outputResolution);
+            final MediaFormat actualVideoOutputFormat = createVideoOutputFormatWithAvailableEncoders(videoFormatMimeType, bitrate, outputResolution);
 
             // setup video composer
             videoComposer = new VideoComposer(mediaExtractor, videoTrackIndex, actualVideoOutputFormat, muxRender, timeScale, trimStartMs, trimEndMs, logger);
@@ -170,9 +172,17 @@ class Mp4ComposerEngine {
     }
 
     @NonNull
-    private static MediaFormat createVideoOutputFormatWithAvailableEncoders(final int bitrate,
+    private static MediaFormat createVideoOutputFormatWithAvailableEncoders(final String mimeType,
+                                                                            final int bitrate,
                                                                             @NonNull final Size outputResolution) {
         final MediaCodecList mediaCodecList = new MediaCodecList(MediaCodecList.REGULAR_CODECS);
+
+        if (!TextUtils.isEmpty(mimeType)) {
+            final MediaFormat mediaFormat = createVideoFormat(mimeType, bitrate, outputResolution);
+            if (mediaCodecList.findEncoderForFormat(mediaFormat) != null) {
+                return mediaFormat;
+            }
+        }
 
         final MediaFormat hevcMediaFormat = createVideoFormat(MediaFormat.MIMETYPE_VIDEO_HEVC, bitrate, outputResolution);
         if (mediaCodecList.findEncoderForFormat(hevcMediaFormat) != null) {


### PR DESCRIPTION
I added a new parameter because there is no way to select video formats in this library.
If selected format is not found, then Mp4Composer selects the format automatically.