### PR TITLE
Fix watermark sample issue

### DIFF
--- a/sample/src/main/java/com/daasuu/sample/FilterType.java
+++ b/sample/src/main/java/com/daasuu/sample/FilterType.java
@@ -197,7 +197,7 @@ public enum FilterType {
             case VIGNETTE:
                 return new GlVignetteFilter();
             case WATERMARK:
-                return new GlWatermarkFilter(BitmapFactory.decodeResource(context.getResources(), R.mipmap.ic_launcher_round), GlWatermarkFilter.Position.RIGHT_BOTTOM);
+                return new GlWatermarkFilter(BitmapFactory.decodeResource(context.getResources(), R.drawable.ic_launcher_sample), GlWatermarkFilter.Position.RIGHT_BOTTOM);
             case WEAK_PIXEL:
                 return new GlWeakPixelInclusionFilter();
             case WHITE_BALANCE:


### PR DESCRIPTION
Will close https://github.com/MasayukiSuda/Mp4Composer-android/issues/77

## Problem
In sample app, watermark filter doesn't work. This is because `BitmapFactory.decodeResource()` can't handle adaptive icon (mipmap resources) and it returns null.

## How to fix
Sample app was changed to pass adaptive icon by this change https://github.com/MasayukiSuda/Mp4Composer-android/commit/05fd8a3073b4761663d4180a490111f67be336c0#diff-a6c1a1c832217b2e1e7e69de5e857903L121 so let's revert change.