### PR TITLE
Allow to listen current time at video transcoding process

### DIFF
--- a/mp4compose/src/main/java/com/daasuu/mp4compose/composer/Mp4Composer.java
+++ b/mp4compose/src/main/java/com/daasuu/mp4compose/composer/Mp4Composer.java
@@ -243,6 +243,13 @@ public class Mp4Composer {
                             listener.onProgress(progress);
                         }
                     }
+
+                    @Override
+                    public void onCurrentWrittenVideoTime(long timeUs) {
+                        if (listener != null) {
+                            listener.onCurrentWrittenVideoTime(timeUs);
+                        }
+                    }
                 });
 
                 final Integer videoRotate = getVideoRotation(srcDataSource);
@@ -374,6 +381,13 @@ public class Mp4Composer {
          * @param progress Progress in [0.0, 1.0] range, or negative value if progress is unknown.
          */
         void onProgress(double progress);
+
+        /**
+         * Called to propagate current time at video transcoding process
+         *
+         * @param timeUs Current time, in Us
+         */
+        void onCurrentWrittenVideoTime(long timeUs);
 
         /**
          * Called when transcode completed.

--- a/mp4compose/src/main/java/com/daasuu/mp4compose/composer/Mp4ComposerEngine.java
+++ b/mp4compose/src/main/java/com/daasuu/mp4compose/composer/Mp4ComposerEngine.java
@@ -267,7 +267,11 @@ class Mp4ComposerEngine {
                     || audioComposer.stepPipeline();
             loopCount++;
             if (durationUs > 0 && loopCount % PROGRESS_INTERVAL_STEPS == 0) {
-                double videoProgress = videoComposer.isFinished() ? 1.0 : Math.min(1.0, (double) videoComposer.getWrittenPresentationTimeUs() / durationUs);
+                long writtenPresentationVideoTimeUs = videoComposer.getWrittenPresentationTimeUs();
+                if (progressCallback != null) {
+                    progressCallback.onCurrentWrittenVideoTime(writtenPresentationVideoTimeUs);
+                }
+                double videoProgress = videoComposer.isFinished() ? 1.0 : Math.min(1.0, (double) writtenPresentationVideoTimeUs / durationUs);
                 double audioProgress = audioComposer.isFinished() ? 1.0 : Math.min(1.0, (double) audioComposer.getWrittenPresentationTimeUs() / durationUs);
                 double progress = (videoProgress + audioProgress) / 2.0;
                 if (progressCallback != null) {
@@ -295,7 +299,11 @@ class Mp4ComposerEngine {
             boolean stepped = videoComposer.stepPipeline();
             loopCount++;
             if (durationUs > 0 && loopCount % PROGRESS_INTERVAL_STEPS == 0) {
-                double videoProgress = videoComposer.isFinished() ? 1.0 : Math.min(1.0, (double) videoComposer.getWrittenPresentationTimeUs() / durationUs);
+                long writtenPresentationVideoTimeUs = videoComposer.getWrittenPresentationTimeUs();
+                if (progressCallback != null) {
+                    progressCallback.onCurrentWrittenVideoTime(writtenPresentationVideoTimeUs);
+                }
+                double videoProgress = videoComposer.isFinished() ? 1.0 : Math.min(1.0, (double) writtenPresentationVideoTimeUs  / durationUs);
                 if (progressCallback != null) {
                     progressCallback.onProgress(videoProgress);
                 }
@@ -320,5 +328,12 @@ class Mp4ComposerEngine {
          * @param progress Progress in [0.0, 1.0] range, or negative value if progress is unknown.
          */
         void onProgress(double progress);
+
+        /**
+         * Called to propagate current time at video transcoding process
+         *
+         * @param timeUs Current time, in Us
+         */
+        void onCurrentWrittenVideoTime(long timeUs);
     }
 }


### PR DESCRIPTION
Extend composer event listener with onCurrentWrittenVideoTime
May used in timed filters, e.g. video captions


